### PR TITLE
Fix gcc-9 error

### DIFF
--- a/distccflags
+++ b/distccflags
@@ -59,7 +59,7 @@ fi
 
 get_arch() {
     $CC -Q --help=target "$@" |
-    egrep '\s*-march=' |
+    egrep '\s*-march=  ' |
     awk '{print $2}'
 }
 


### PR DESCRIPTION
This error seems to have popped up for me when using this with gcc-9:
```
gcc: error: valid: No such file or directory
```
Increasing the number of spaces after `=` in the `egrep` pattern of `get_arch()` seemed to solve the issue.